### PR TITLE
Added constant to activate compressor toggle

### DIFF
--- a/ChronosTankDrive/src/main/java/frc/robot/Constants.java
+++ b/ChronosTankDrive/src/main/java/frc/robot/Constants.java
@@ -91,4 +91,8 @@ public class Constants {
         public static final double TURN_SCALE = 0.5;
 
     }
+
+    public static final class Pneumatics {
+        public static final boolean COMPRESSOR_TOGGLE_ENABLED = false;
+    }
 }

--- a/ChronosTankDrive/src/main/java/frc/robot/Robot.java
+++ b/ChronosTankDrive/src/main/java/frc/robot/Robot.java
@@ -27,6 +27,7 @@ import com.revrobotics.CANSparkMaxLowLevel.MotorType;
 import static frc.robot.Constants.IDS.*;
 import static frc.robot.Constants.Limelight.*;
 import static frc.robot.Constants.Drive.*;
+import static frc.robot.Constants.Pneumatics.*;
 //import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 //import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 //import edu.wpi.first.cscore.UsbCamera;
@@ -214,7 +215,7 @@ public class Robot extends TimedRobot {
       subSystem.periodic();
     }
 
-    if (weaponStick.getRawButtonReleased(9)) {
+    if (COMPRESSOR_TOGGLE_ENABLED && weaponStick.getRawButtonReleased(9)) {
       if (compressor.enabled()) {
         compressor.disable();
       } else {


### PR DESCRIPTION
A new constant determines if the comapressor state can be toggled by a joystick button. This way, the code can be disabled during competition, but is still available for testing.